### PR TITLE
Issue #49: Page deletion fix

### DIFF
--- a/src/core/page/PageDelete.tsx
+++ b/src/core/page/PageDelete.tsx
@@ -10,9 +10,13 @@ const PageDelete: React.FC<{ onClose: () => void, articleId: StencilClient.Artic
   const { enqueueSnackbar } = useSnackbar();
   const { service, actions, site } = Composer.useComposer();
   const [pageId, setPageId] = React.useState('');
-
+  const tabs = Burger.useTabs();
 
   const handleDelete = () => {
+    var pageTab = tabs.session.tabs.find(tab => tab.id === props.articleId)
+    if (pageTab) {
+      tabs.actions.handleTabClose(pageTab);
+    }
     service.delete().page(pageId).then(_success => {
       enqueueSnackbar(message, { variant: 'warning' });
       props.onClose();

--- a/src/core/page/PageDelete.tsx
+++ b/src/core/page/PageDelete.tsx
@@ -14,10 +14,10 @@ const PageDelete: React.FC<{ onClose: () => void, articleId: StencilClient.Artic
 
   const handleDelete = () => {
     var pageTab = tabs.session.tabs.find(tab => tab.id === props.articleId)
-    if (pageTab) {
-      tabs.actions.handleTabClose(pageTab);
-    }
     service.delete().page(pageId).then(_success => {
+      if (pageTab) {
+        tabs.actions.handleTabClose(pageTab);
+      }
       enqueueSnackbar(message, { variant: 'warning' });
       props.onClose();
       actions.handleLoadSite();


### PR DESCRIPTION
- Checking if the to-be-deleted page is already opened in a tab
- If yes, call the `handleTabClose` action and then proceed with deletion