### PR TITLE
Issue #62: Build info

### DIFF
--- a/build-scripts/main-release.sh
+++ b/build-scripts/main-release.sh
@@ -22,6 +22,9 @@ readonly local PROJECT_VERSION_NEXT=$(node -e "console.log(require('./package.js
 
 # Log
 echo "Project version: '${PROJECT_VERSION}' next: '${PROJECT_VERSION_NEXT}'"
+NEWLINE=$'\n'
+DATE=$(date +"%d/%m/%Y")
+echo "const version = {tag: '${PROJECT_VERSION_NEXT}', built: '${DATE}'};${NEWLINE}export default version;" > ./src/core/version.ts
 
 # Tag and publish
 yarn install

--- a/src/core/ActivitiesView.tsx
+++ b/src/core/ActivitiesView.tsx
@@ -183,9 +183,9 @@ const ActivitiesView: React.FC<{}> = () => {
   const [coreVersionDate, setCoreVersionDate] = React.useState<string>();
 
   service.version().version().then((version) => {
-    const versionInfo = version.split(";");
-    setCoreVersion(versionInfo[0]);
-    setCoreVersionDate(versionInfo[1]);
+    console.log(version);
+    setCoreVersion(version.version);
+    setCoreVersionDate(version.built);
   });
 
   return (

--- a/src/core/ActivitiesView.tsx
+++ b/src/core/ActivitiesView.tsx
@@ -19,6 +19,7 @@ import { TemplateComposer } from './template';
 
 import { Composer, StencilClient } from './context';
 
+import version from './version';
 
 interface CardData {
   type: CardType;
@@ -172,10 +173,20 @@ const ActivitiesView: React.FC<{}> = () => {
   const theme = useTheme();
   const { actions } = Burger.useTabs();
   const { site } = Composer.useComposer();
+  const { service } = Composer.useComposer();
 
   const [open, setOpen] = React.useState<number>();
   const handleClose = () => setOpen(undefined);
   const cards = React.useMemo(() => createCards(site, theme, actions), [site, theme, actions]);
+
+  const [coreVersion, setCoreVersion] = React.useState<string>();
+  const [coreVersionDate, setCoreVersionDate] = React.useState<string>();
+
+  service.version().version().then((version) => {
+    const versionInfo = version.split(";");
+    setCoreVersion(versionInfo[0]);
+    setCoreVersionDate(versionInfo[1]);
+  });
 
   return (
     <>
@@ -192,7 +203,12 @@ const ActivitiesView: React.FC<{}> = () => {
         {open === undefined ? null : (cards[open].composer(handleClose))}
         {cards.map((card, index) => (<ActivitiesViewItem key={index} data={card} onCreate={() => setOpen(index)} />))}
       </Box>
-
+      <Typography variant="caption" sx={{ pt: 1 }} display={'flex'} flexDirection={'column'} alignItems={'center'}>
+          <FormattedMessage id={"activities.version.composer"} values={{ version: version.tag, date: version.built}}/>
+          <Typography variant="caption" sx={{ pt: 1 }} >
+            <FormattedMessage id={"activities.version.core"} values={{ version: coreVersion, date: coreVersionDate}}/>
+          </Typography>
+      </Typography>
     </>
   );
 }

--- a/src/core/client/StencilClient.ts
+++ b/src/core/client/StencilClient.ts
@@ -192,6 +192,7 @@ declare namespace StencilClient {
     create(): CreateBuilder;
     delete(): DeleteBuilder;
     update(): UpdateBuilder;
+    version(): VersionBuilder;
   }
 
   interface CreateArticle {
@@ -264,6 +265,9 @@ declare namespace StencilClient {
     link(link: LinkMutator): Promise<Link>;
     workflow(workflow: WorkflowMutator): Promise<Workflow>;
     template(template: TemplateMutator): Promise<Template>;
+  }
+  interface VersionBuilder {
+    version(): Promise<string>;
   }
   interface Store {
     fetch<T>(path: string, init?: RequestInit): Promise<T>;

--- a/src/core/client/StencilClient.ts
+++ b/src/core/client/StencilClient.ts
@@ -267,7 +267,11 @@ declare namespace StencilClient {
     template(template: TemplateMutator): Promise<Template>;
   }
   interface VersionBuilder {
-    version(): Promise<string>;
+    version(): Promise<VersionEntity>;
+  }
+  interface VersionEntity {
+    version: string;
+    built: string;
   }
   interface Store {
     fetch<T>(path: string, init?: RequestInit): Promise<T>;

--- a/src/core/client/impl.ts
+++ b/src/core/client/impl.ts
@@ -135,7 +135,7 @@ class VersionBuilderImpl implements StencilClient.VersionBuilder {
   constructor(backend: StencilClient.Store) {
     this._backend = backend;
   }
-  async version(): Promise<string> {
+  async version(): Promise<StencilClient.VersionEntity> {
     return this._backend.fetch(`/version`, { method: "GET" }).then((data) => data as any)
   }
 }

--- a/src/core/client/impl.ts
+++ b/src/core/client/impl.ts
@@ -32,7 +32,8 @@ const createService = (init: { store?: StencilClient.Store, config?: StencilClie
     },
     create: () => new CreateBuilderImpl(backend),
     update: () => new UpdateBuilderImpl(backend),
-    delete: () => new DeleteBuilderImpl(backend)
+    delete: () => new DeleteBuilderImpl(backend),
+    version: () => new VersionBuilderImpl(backend)
   };
 }
 
@@ -126,6 +127,16 @@ class DeleteBuilderImpl implements StencilClient.DeleteBuilder {
   }
   async template(init: StencilClient.TemplateId): Promise<void> {
     return this._backend.fetch(`/templates/${init}`, { method: "DELETE" }).then((data) => data as any)
+  }
+}
+
+class VersionBuilderImpl implements StencilClient.VersionBuilder {
+  private _backend: StencilClient.Store;
+  constructor(backend: StencilClient.Store) {
+    this._backend = backend;
+  }
+  async version(): Promise<string> {
+    return this._backend.fetch(`/version`, { method: "GET" }).then((data) => data as any)
   }
 }
 

--- a/src/core/client/mock.ts
+++ b/src/core/client/mock.ts
@@ -204,9 +204,9 @@ class MockDeleteBuilder implements StencilClient.DeleteBuilder {
 }
 
 class MockVersionBuilder implements StencilClient.VersionBuilder {
-  async version(): Promise<string> {
+  async version(): Promise<StencilClient.VersionEntity> {
     const date = new Date().toLocaleDateString("en-GB");
-    return "mock; " + date;
+    return { version: "mock", built: date.toString() };
   }
 }
 

--- a/src/core/client/mock.ts
+++ b/src/core/client/mock.ts
@@ -114,7 +114,8 @@ const createMock = (): StencilClient.Service => {
     },
     create: () => new MockCreateBuilder(),
     update: () => new MockUpdateBuilder(),
-    delete: () => new MockDeleteBuilder()
+    delete: () => new MockDeleteBuilder(),
+    version: () => new MockVersionBuilder(),
   } as any;
 }
 
@@ -202,6 +203,12 @@ class MockDeleteBuilder implements StencilClient.DeleteBuilder {
   }
 }
 
+class MockVersionBuilder implements StencilClient.VersionBuilder {
+  async version(): Promise<string> {
+    const date = new Date().toLocaleDateString("en-GB");
+    return "mock; " + date;
+  }
+}
 
 const toRecord = (entities: { id: string }[]): Record<string, any> => {
   const result: Record<string, any> = {};

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,2 @@
+const version = { tag: "dev", built: new Date().toLocaleDateString("en-GB") };
+export default version;

--- a/src/intl/en.ts
+++ b/src/intl/en.ts
@@ -50,6 +50,9 @@ const en = {
   'activities.templates.title': 'Templates',
   'activities.templates.desc': 'Use templates to customise and standardise a page default Markdown content and/or structure. Templates can be applied to new pages upon creation. ',
 
+  'activities.version.composer': 'Composer: build version {version}, build date {date}',
+  'activities.version.core': 'Core: build version {version}, build date {date}',
+
   'templates': 'Templates',
   'template.name': 'Name',
   'template.name.desc': 'User-given name for this template',


### PR DESCRIPTION
### Build info feature
- Modified the release script to save release information (tag and date) into a `version.ts` file
- Added an API call to `/version` endpoint
- Build info for both the core and the composer displayed in Activities view