### PR TITLE
Issue #51: Development mode

### DIFF
--- a/src/core/Toolbar.tsx
+++ b/src/core/Toolbar.tsx
@@ -56,6 +56,7 @@ const Toolbar: React.FC<{}> = () => {
   const unsavedPages = Object.values(composer.session.pages).filter(p => !p.saved);
   const unsavedArticlePages: Composer.PageUpdate[] = (article ? unsavedPages.filter(p => !p.saved).filter(p => p.origin.body.article === article.id) : []);
 
+  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const message = <FormattedMessage id="snack.page.savedMessage" />
 
@@ -65,7 +66,7 @@ const Toolbar: React.FC<{}> = () => {
       if (unsavedArticlePages.length === 0) {
         return;
       }
-      const update: StencilClient.PageMutator[] = unsavedArticlePages.map(p => ({ pageId: p.origin.id, locale: p.origin.body.locale, content: p.value }));
+      const update: StencilClient.PageMutator[] = unsavedArticlePages.map(p => ({ pageId: p.origin.id, locale: p.origin.body.locale, content: p.value, devMode }));
       composer.service.update().pages(update).then(success => {
         enqueueSnackbar(message, {variant: 'success'});
         composer.actions.handlePageUpdateRemove(success.map(p => p.id));

--- a/src/core/Toolbar.tsx
+++ b/src/core/Toolbar.tsx
@@ -56,8 +56,6 @@ const Toolbar: React.FC<{}> = () => {
   const unsavedPages = Object.values(composer.session.pages).filter(p => !p.saved);
   const unsavedArticlePages: Composer.PageUpdate[] = (article ? unsavedPages.filter(p => !p.saved).filter(p => p.origin.body.article === article.id) : []);
 
-  const [devMode, setDevMode] = React.useState<boolean>(true);
-
   const message = <FormattedMessage id="snack.page.savedMessage" />
 
   const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
@@ -66,7 +64,7 @@ const Toolbar: React.FC<{}> = () => {
       if (unsavedArticlePages.length === 0) {
         return;
       }
-      const update: StencilClient.PageMutator[] = unsavedArticlePages.map(p => ({ pageId: p.origin.id, locale: p.origin.body.locale, content: p.value, devMode }));
+      const update: StencilClient.PageMutator[] = unsavedArticlePages.map(p => ({ pageId: p.origin.id, locale: p.origin.body.locale, content: p.value, devMode: p.origin.body.devMode }));
       composer.service.update().pages(update).then(success => {
         enqueueSnackbar(message, {variant: 'success'});
         composer.actions.handlePageUpdateRemove(success.map(p => p.id));

--- a/src/core/article/ArticleComposer.tsx
+++ b/src/core/article/ArticleComposer.tsx
@@ -100,7 +100,7 @@ const ArticleComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
             .map(view => view.article)
             .map(({ id, body }) => ({
               id,
-              value: (<ListItem sx={ body.parentId ? { ml: 2, color: 'article.dark' } : undefined }>{`${body.order} - ${body.name}`}</ListItem>)
+              value: (<Box sx={ body.parentId ? { ml: 2, color: 'article.dark' } : undefined }>{`${body.order} - ${body.name}`}</Box>)
             }))}
         />
         <Box display='flex'>

--- a/src/core/article/ArticleComposer.tsx
+++ b/src/core/article/ArticleComposer.tsx
@@ -70,9 +70,10 @@ const ArticleComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [name, setName] = React.useState("");
   const [order, setOrder] = React.useState(0);
   const [parentId, setParentId] = React.useState("");
+  const [devMode, setDevMode] = React.useState<boolean>(true);
     
   const handleCreate = () => {
-    const entity: StencilClient.CreateArticle = { name, parentId: parentId && parentId !== DUMMY_ID ? parentId : undefined, order };
+    const entity: StencilClient.CreateArticle = { name, parentId: parentId && parentId !== DUMMY_ID ? parentId : undefined, order, devMode };
     console.log("entity", entity)
 
     service.create().article(entity).then(success => {
@@ -119,6 +120,14 @@ const ArticleComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           value={name}
           onChange={setName}
         />
+        <Box maxWidth="50%" sx={{ ml: 1 }}>
+          <Burger.Switch
+            checked={devMode}
+            helperText="services.devmode.helper"
+            label="services.devmode"
+            onChange={setDevMode}
+          />
+        </Box>
       </>
     </Burger.Dialog>
   );

--- a/src/core/article/ArticleComposer.tsx
+++ b/src/core/article/ArticleComposer.tsx
@@ -53,7 +53,7 @@ const OrderNumberTooltip: React.FC<{}> = () => {
           .map(view => view.article)
           .sort((l0, l1) => l0.body.order - l1.body.order)
           .map(({ id, body }) => (
-           <ListItem sx={ body.parentId ? { ml: 2, color: 'article.dark', pb: 1,  } : {pb: 1} }>{`${body.order} - ${body.name}`}</ListItem>
+           <ListItem key={id} sx={ body.parentId ? { ml: 2, color: 'article.dark', pb: 1,  } : {pb: 1} }>{`${body.order} - ${body.name}`}</ListItem>
           ))}
       </Typography>
     </Popover>
@@ -70,11 +70,10 @@ const ArticleComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [name, setName] = React.useState("");
   const [order, setOrder] = React.useState(0);
   const [parentId, setParentId] = React.useState("");
-  const [devMode, setDevMode] = React.useState<boolean>(true);
+  const [devMode, setDevMode] = React.useState<boolean>(false);
     
   const handleCreate = () => {
     const entity: StencilClient.CreateArticle = { name, parentId: parentId && parentId !== DUMMY_ID ? parentId : undefined, order, devMode };
-    console.log("entity", entity)
 
     service.create().article(entity).then(success => {
       console.log(success)

--- a/src/core/article/ArticleComposer.tsx
+++ b/src/core/article/ArticleComposer.tsx
@@ -123,8 +123,8 @@ const ArticleComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         <Box maxWidth="50%" sx={{ ml: 1 }}>
           <Burger.Switch
             checked={devMode}
-            helperText="services.devmode.helper"
-            label="services.devmode"
+            helperText="article.devmode.helper"
+            label="article.devmode"
             onChange={setDevMode}
           />
         </Box>

--- a/src/core/article/ArticleEdit.tsx
+++ b/src/core/article/ArticleEdit.tsx
@@ -65,8 +65,8 @@ const ArticleEdit: React.FC<{ articleId: StencilClient.ArticleId, onClose: () =>
       <Box maxWidth="50%" sx={{ ml: 1 }}>
         <Burger.Switch
           checked={devMode ? devMode : false}
-          helperText="services.devmode.helper"
-          label="services.devmode"
+          helperText="article.devmode.helper"
+          label="article.devmode"
           onChange={setDevMode}
         />
       </Box>

--- a/src/core/article/ArticleEdit.tsx
+++ b/src/core/article/ArticleEdit.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import Burger from '@the-wrench-io/react-burger';
 import { Composer, StencilClient } from '../context';
+import { Box } from '@mui/material';
 
 
 const selectSub = { ml: 2, color: "article.dark" }
@@ -17,11 +18,12 @@ const ArticleEdit: React.FC<{ articleId: StencilClient.ArticleId, onClose: () =>
   const [name, setName] = React.useState(article.body.name);
   const [order, setOrder] = React.useState(article.body.order);
   const [parentId, setParentId] = React.useState(article.body.parentId);
+  const [devMode, setDevMode] = React.useState(article.body.devMode);
 
   const message = <FormattedMessage id="snack.article.editedMessage" />
 
   const handleUpdate = () => {
-    const entity: StencilClient.ArticleMutator = { articleId: article.id, name, parentId, order, links: undefined, workflows: undefined };
+    const entity: StencilClient.ArticleMutator = { articleId: article.id, name, parentId, order, links: undefined, workflows: undefined, devMode };
     service.update().article(entity).then(_success => {
       enqueueSnackbar(message, {variant: 'success'});
       onClose();
@@ -60,6 +62,14 @@ const ArticleEdit: React.FC<{ articleId: StencilClient.ArticleId, onClose: () =>
       />
       <Burger.NumberField label="order" helperText="article.edit.orderhelper" placeholder={100} value={order} onChange={setOrder} />
       <Burger.TextField label="article.name" required value={name} onChange={setName} />
+      <Box maxWidth="50%" sx={{ ml: 1 }}>
+        <Burger.Switch
+          checked={devMode ? devMode : false}
+          helperText="services.devmode.helper"
+          label="services.devmode"
+          onChange={setDevMode}
+        />
+      </Box>
     </>
   </Burger.Dialog>);
 }

--- a/src/core/article/ArticleLinksComposer.tsx
+++ b/src/core/article/ArticleLinksComposer.tsx
@@ -12,7 +12,7 @@ const ArticleLinksComposer: React.FC<{ articleId: StencilClient.ArticleId }> = (
   const { service, actions, site, session } = Composer.useComposer();
   const tabs = Burger.useTabs();
   const view = session.getArticleView(props.articleId);
-
+  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const links: StencilClient.Link[] = Object.values(site.links)
     .map((w) => ({ w, name: session.getLinkName(w.id)?.name }))
@@ -27,7 +27,8 @@ const ArticleLinksComposer: React.FC<{ articleId: StencilClient.ArticleId }> = (
       parentId: article.body.parentId,
       order: article.body.order,
       links: [...selectedLinks],
-      workflows: undefined
+      workflows: undefined,
+      devMode,
     };
     service.update().article(entity)
       .then(_success => actions.handleLoadSite())

--- a/src/core/article/ArticleLinksComposer.tsx
+++ b/src/core/article/ArticleLinksComposer.tsx
@@ -12,7 +12,6 @@ const ArticleLinksComposer: React.FC<{ articleId: StencilClient.ArticleId }> = (
   const { service, actions, site, session } = Composer.useComposer();
   const tabs = Burger.useTabs();
   const view = session.getArticleView(props.articleId);
-  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const links: StencilClient.Link[] = Object.values(site.links)
     .map((w) => ({ w, name: session.getLinkName(w.id)?.name }))
@@ -28,7 +27,7 @@ const ArticleLinksComposer: React.FC<{ articleId: StencilClient.ArticleId }> = (
       order: article.body.order,
       links: [...selectedLinks],
       workflows: undefined,
-      devMode,
+      devMode: article.body.devMode
     };
     service.update().article(entity)
       .then(_success => actions.handleLoadSite())

--- a/src/core/article/ArticleWorkflowsComposer.tsx
+++ b/src/core/article/ArticleWorkflowsComposer.tsx
@@ -14,7 +14,6 @@ const ArticleWorkflowsComposer: React.FC<{ articleId: StencilClient.ArticleId }>
   const { enqueueSnackbar } = useSnackbar();
   const { service, actions, site, session } = Composer.useComposer();
   const layout = Burger.useTabs();
-  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const view = session.getArticleView(props.articleId);
   const workflows: StencilClient.Workflow[] = Object.values(site.workflows)
@@ -31,7 +30,7 @@ const ArticleWorkflowsComposer: React.FC<{ articleId: StencilClient.ArticleId }>
       order: article.body.order,
       workflows: [...selectedWorkflows],
       links: undefined,
-      devMode,
+      devMode: article.body.devMode
     };
     console.log("saving selected services" + selectedWorkflows);
     service.update().article(entity)

--- a/src/core/article/ArticleWorkflowsComposer.tsx
+++ b/src/core/article/ArticleWorkflowsComposer.tsx
@@ -14,6 +14,7 @@ const ArticleWorkflowsComposer: React.FC<{ articleId: StencilClient.ArticleId }>
   const { enqueueSnackbar } = useSnackbar();
   const { service, actions, site, session } = Composer.useComposer();
   const layout = Burger.useTabs();
+  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const view = session.getArticleView(props.articleId);
   const workflows: StencilClient.Workflow[] = Object.values(site.workflows)
@@ -29,7 +30,8 @@ const ArticleWorkflowsComposer: React.FC<{ articleId: StencilClient.ArticleId }>
       parentId: article.body.parentId,
       order: article.body.order,
       workflows: [...selectedWorkflows],
-      links: undefined
+      links: undefined,
+      devMode,
     };
     console.log("saving selected services" + selectedWorkflows);
     service.update().article(entity)

--- a/src/core/client/StencilClient.ts
+++ b/src/core/client/StencilClient.ts
@@ -51,7 +51,8 @@ declare namespace StencilClient {
     body: {
       article: ArticleId,
       locale: Locale,
-      content: LocalisedMarkdown
+      content: LocalisedMarkdown,
+      devMode?: boolean
     }
   }
 
@@ -59,6 +60,7 @@ declare namespace StencilClient {
     pageId: PageId,
     locale: Locale;
     content: LocalisedContent;
+    devMode: boolean | undefined;
   }
 
   interface Template {
@@ -75,7 +77,7 @@ declare namespace StencilClient {
     id: TemplateId,
     type: TemplateType,
     name: string,
-    description: string
+    description: string,
     content: string,
   }
 
@@ -85,6 +87,7 @@ declare namespace StencilClient {
       parentId?: ArticleId,
       name: string,
       order: number,
+      devMode?: boolean,
     }
   }
 
@@ -95,6 +98,7 @@ declare namespace StencilClient {
     order: number,
     links: LinkId[] | undefined,
     workflows: WorkflowId[] | undefined,
+    devMode: boolean | undefined,
   }
 
   interface Release {
@@ -146,6 +150,7 @@ declare namespace StencilClient {
       contentType: LinkType,
       value: string, //url, phone number
       labels: LocaleLabel[],
+      devMode?: boolean,
     }
   }
 
@@ -161,6 +166,7 @@ declare namespace StencilClient {
     value: string,
     articles: ArticleId[] | undefined,
     labels: LocaleLabel[] | undefined,
+    devMode: boolean | undefined
   }
 
   interface Workflow {
@@ -198,6 +204,7 @@ declare namespace StencilClient {
     parentId?: ArticleId;
     name: string;
     order: number;
+    devMode: boolean | undefined;
   }
 
   interface CreateLocale {
@@ -206,7 +213,8 @@ declare namespace StencilClient {
   interface CreatePage {
     articleId: ArticleId;
     locale: LocaleId;
-    content?: string
+    content?: string;
+    devMode: boolean | undefined;
   }
   interface CreateTemplate {
     type: "page" | string;
@@ -220,13 +228,14 @@ declare namespace StencilClient {
     value: string;
     labels: LocaleLabel[];
     articles: ArticleId[];
+    devMode: boolean | undefined;
   }
 
   interface CreateWorkflow {
     value: string;
     labels: LocaleLabel[];
     articles: ArticleId[];
-    devMode: boolean | undefined
+    devMode: boolean | undefined;
   }
   interface CreateRelease {
     name: string,

--- a/src/core/explorer/article/ArticleItem.tsx
+++ b/src/core/explorer/article/ArticleItem.tsx
@@ -47,6 +47,7 @@ interface LinkItemProps {
   nodeId: string;
   children?: React.ReactChild;
   onClick: () => void;
+  devMode?: boolean;
 }
 
 const LinkItem: React.FC<LinkItemProps> = (props) => {
@@ -56,7 +57,7 @@ const LinkItem: React.FC<LinkItemProps> = (props) => {
       onClick={props.onClick}
       label={
         <Box sx={{ display: "flex", alignItems: "center", p: 0.5, pr: 0 }}>
-          <Box component={LinkIcon} color="link.main" sx={{ pl: 1, mr: 1 }} />
+          <Box component={props.devMode ? ConstructionIcon : LinkIcon} color="link.main" sx={{ pl: 1, mr: 1 }} />
           <Typography align="left" maxWidth="300px" noWrap={true} variant="body2"
             sx={{ fontWeight: "inherit", flexGrow: 1 }}
           >
@@ -97,7 +98,7 @@ const ArticleItem: React.FC<{
   const articleName = session.getArticleName(view.article.id);
   return (
     <>
-      <Burger.TreeItem nodeId={nodeId ? nodeId : article.id} labelText={articleName.name} labelIcon={ArticleOutlinedIcon} labelcolor={saved ? "explorerItem" : "explorerItem.contrastText"}>
+      <Burger.TreeItem nodeId={nodeId ? nodeId : article.id} labelText={articleName.name} labelIcon={article.body.devMode ? ConstructionIcon : ArticleOutlinedIcon} labelcolor={saved ? "explorerItem" : "explorerItem.contrastText"}>
 
         {/** Article options */
           options ? (<Burger.TreeItem nodeId={article.id + 'article-options-nested'}
@@ -155,7 +156,8 @@ const ArticleItem: React.FC<{
               .map(view => (<LinkItem key={view.link.id}
                 labelText={session.getLinkName(view.link.id).name}
                 nodeId={view.link.id}
-                onClick={() => options.setEditLink(view.link.id)} />)
+                onClick={() => options.setEditLink(view.link.id)} 
+                devMode={view.link.body.devMode} />)
               )}
           </Burger.TreeItem>) : null
 

--- a/src/core/explorer/article/ArticleOptions.tsx
+++ b/src/core/explorer/article/ArticleOptions.tsx
@@ -7,7 +7,7 @@ import EditIcon from '@mui/icons-material/ModeEdit';
 import { LinkComposer } from '../../link';
 import { WorkflowComposer } from '../../workflow';
 import { ArticleEdit, ArticleDelete } from '../../article';
-import { NewPage, PageEdit, PageDelete } from '../../page';
+import { NewPage, PageEdit, PageDelete, PageEditDev } from '../../page';
 import { Composer, StencilClient } from '../../context';
 import Burger from '@the-wrench-io/react-burger';
 
@@ -17,7 +17,7 @@ interface ArticleOptionsProps {
 }
 const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
 
-  const [dialogOpen, setDialogOpen] = React.useState<undefined | 'ArticleEdit' | 'NewPage' | 'PageEdit' | 'PageDelete' | 'ArticleDelete' | 'LinkComposer' | 'WorkflowComposer'>(undefined);
+  const [dialogOpen, setDialogOpen] = React.useState<undefined | 'ArticleEdit' | 'NewPage' | 'PageEdit' | 'PageEditDev' | 'PageDelete' | 'ArticleDelete' | 'LinkComposer' | 'WorkflowComposer'>(undefined);
 
 
   const handleDialogClose = () => setDialogOpen(undefined);
@@ -28,6 +28,7 @@ const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
       { dialogOpen === 'ArticleEdit' ? <ArticleEdit articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'NewPage' ? <NewPage articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'PageEdit' ? <PageEdit articleId={article.id} onClose={handleDialogClose} /> : null}
+      { dialogOpen === 'PageEditDev' ? <PageEditDev articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'PageDelete' ? <PageDelete articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'ArticleDelete' ? <ArticleDelete articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'LinkComposer' ? <LinkComposer onClose={handleDialogClose} /> : null}
@@ -60,13 +61,18 @@ const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
         onClick={() => setDialogOpen('PageEdit')}
         labelText={<FormattedMessage id="pages.change" />}>
       </Burger.TreeItemOption>
+      <Burger.TreeItemOption nodeId={article.id + 'pages.devmode'}
+        color='page'
+        icon={EditIcon}
+        onClick={() => setDialogOpen('PageEditDev')}
+        labelText={<FormattedMessage id="pages.devmode" />}>
+      </Burger.TreeItemOption>
       <Burger.TreeItemOption nodeId={article.id + 'pages.delete'}
         color='page'
         icon={DeleteOutlineOutlinedIcon}
         onClick={() => setDialogOpen('PageDelete')}
         labelText={<FormattedMessage id="pages.delete" />}>
       </Burger.TreeItemOption>
-
       <Burger.TreeItemOption nodeId={article.id + 'resource.create.workflows'}
         color='workflow'
         icon={AddCircleOutlineIcon}

--- a/src/core/explorer/article/ArticleOptions.tsx
+++ b/src/core/explorer/article/ArticleOptions.tsx
@@ -7,7 +7,7 @@ import EditIcon from '@mui/icons-material/ModeEdit';
 import { LinkComposer } from '../../link';
 import { WorkflowComposer } from '../../workflow';
 import { ArticleEdit, ArticleDelete } from '../../article';
-import { NewPage, PageEdit, PageDelete, PageEditDev } from '../../page';
+import { NewPage, PageEdit, PageDelete, PageEditDevMode } from '../../page';
 import { Composer, StencilClient } from '../../context';
 import Burger from '@the-wrench-io/react-burger';
 
@@ -19,7 +19,7 @@ const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
 
   const [dialogOpen, setDialogOpen] = React.useState<undefined | 'ArticleEdit' | 'NewPage' | 'PageEdit' | 'PageEditDev' | 'PageDelete' | 'ArticleDelete' | 'LinkComposer' | 'WorkflowComposer'>(undefined);
 
-
+  const { site } = Composer.useComposer();
   const handleDialogClose = () => setDialogOpen(undefined);
   const { handleInTab } = Composer.useNav();
 
@@ -28,7 +28,7 @@ const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
       { dialogOpen === 'ArticleEdit' ? <ArticleEdit articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'NewPage' ? <NewPage articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'PageEdit' ? <PageEdit articleId={article.id} onClose={handleDialogClose} /> : null}
-      { dialogOpen === 'PageEditDev' ? <PageEditDev articleId={article.id} onClose={handleDialogClose} /> : null}
+      { dialogOpen === 'PageEditDev' ? <PageEditDevMode articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'PageDelete' ? <PageDelete articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'ArticleDelete' ? <ArticleDelete articleId={article.id} onClose={handleDialogClose} /> : null}
       { dialogOpen === 'LinkComposer' ? <LinkComposer onClose={handleDialogClose} /> : null}
@@ -61,12 +61,12 @@ const ArticleOptions: React.FC<ArticleOptionsProps> = ({ article }) => {
         onClick={() => setDialogOpen('PageEdit')}
         labelText={<FormattedMessage id="pages.change" />}>
       </Burger.TreeItemOption>
-      <Burger.TreeItemOption nodeId={article.id + 'pages.devmode'}
+      {Object.values(site.pages).filter(p => p.body.article === article.id).length > 0 && <Burger.TreeItemOption nodeId={article.id + 'pages.change.devmode'}
         color='page'
         icon={EditIcon}
         onClick={() => setDialogOpen('PageEditDev')}
-        labelText={<FormattedMessage id="pages.devmode" />}>
-      </Burger.TreeItemOption>
+        labelText={<FormattedMessage id="pages.change.devmode" />}>
+      </Burger.TreeItemOption>}
       <Burger.TreeItemOption nodeId={article.id + 'pages.delete'}
         color='page'
         icon={DeleteOutlineOutlinedIcon}

--- a/src/core/explorer/article/ArticlePageItem.tsx
+++ b/src/core/explorer/article/ArticlePageItem.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Theme, useTheme } from "@mui/material";
 
 import LeftEditIcon from "@mui/icons-material/BorderLeft";
 import RightEditIcon from "@mui/icons-material/BorderRight";
+import ConstructionIcon from '@mui/icons-material/Construction';
 
 import Burger from '@the-wrench-io/react-burger';
 import { Composer } from '../../context';
@@ -10,7 +11,7 @@ import { Composer } from '../../context';
 
 
 
-const ArticlePageItem: React.FC<{ article: Composer.ArticleView, page: Composer.PageView, saved?: boolean}> = (props) => {
+const ArticlePageItem: React.FC<{ article: Composer.ArticleView, page: Composer.PageView, saved?: boolean }> = (props) => {
 
   const theme = useTheme<Theme>();
   const localeIconColor = theme.palette.page.main;
@@ -39,7 +40,14 @@ const ArticlePageItem: React.FC<{ article: Composer.ArticleView, page: Composer.
       handleInTab({ article, type: "ARTICLE_PAGES", locale: page.body.locale, secondary })
     }
   }
-  
+
+  const icon = () => {
+    if (page.body.devMode && page.body.devMode === true) {
+      return <ConstructionIcon />
+    } else {
+      return <LeftEditIcon />
+    }
+  }
 
   return (
     <Burger.TreeItemRoot
@@ -51,7 +59,7 @@ const ArticlePageItem: React.FC<{ article: Composer.ArticleView, page: Composer.
       label={
 
         <Box sx={{ display: "flex", alignItems: "center", p: 0.5, pr: 0 }}>
-          <Box component={LeftEditIcon} color={props.saved === false ? 
+          <Box component={icon} color={props.saved === false ? 
             "explorerItem.contrastText": 
             (nav?.value === page.body.locale ? localeIconColor : "inherit")} />
           

--- a/src/core/explorer/link/LinkItem.tsx
+++ b/src/core/explorer/link/LinkItem.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import LinkIcon from '@mui/icons-material/Link';
 import EditIcon from '@mui/icons-material/ModeEdit';
+import ConstructionIcon from '@mui/icons-material/Construction';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -26,7 +27,7 @@ const LinkItem: React.FC<{ linkId: StencilClient.LinkId }> = ({ linkId }) => {
         nodeId={link.id}
         labelText={workflowName.name}
         labelcolor="explorerItem"
-        labelIcon={LinkIcon}
+        labelIcon={link.body.devMode ? ConstructionIcon : LinkIcon}
         >
 
         <Burger.TreeItem nodeId={link.id + 'options-nested'} labelText={<FormattedMessage id="options" />} labelIcon={EditIcon}>

--- a/src/core/explorer/search/SearchExplorer.tsx
+++ b/src/core/explorer/search/SearchExplorer.tsx
@@ -102,7 +102,7 @@ const LinkItem: React.FC<{ view: Composer.LinkView, searchResult: Composer.Searc
         nodeId={view.link.id}
         labelText={view.link.body.value}
         labelcolor="link"
-        labelIcon={LinkIcon}>
+        labelIcon={view.link.body.devMode ? ConstructionIcon : LinkIcon}>
         {items}
       </Burger.TreeItem>
     </>)
@@ -206,7 +206,7 @@ const ArticleItem: React.FC<{ view: Composer.ArticleView, searchResult: Composer
         nodeId={view.article.id}
         labelText={<span>{findMatch(`${view.article.body.name}`, keyword, true)}</span>}
         labelcolor="page"
-        labelIcon={ArticleOutlinedIcon}
+        labelIcon={view.article.body.devMode ? ConstructionIcon : ArticleOutlinedIcon}
         onClick={() => {
           if (items.length === 0) {
             setArticleEditOpen(true)

--- a/src/core/link/LinkComposer.tsx
+++ b/src/core/link/LinkComposer.tsx
@@ -21,7 +21,7 @@ const LinkComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [changeInProgress, setChangeInProgress] = React.useState(false);
   const [articleId, setArticleId] = React.useState<StencilClient.ArticleId[]>([]);
   //const articles: StencilClient.Article[] = Object.values(site.articles);
-  const [devMode, setDevMode] = React.useState<boolean>(true);
+  const [devMode, setDevMode] = React.useState<boolean>(false);
 
   const handleCreate = () => {
     const entity: StencilClient.CreateLink = { type, value, articles: articleId, labels, devMode };

--- a/src/core/link/LinkComposer.tsx
+++ b/src/core/link/LinkComposer.tsx
@@ -105,8 +105,8 @@ const LinkComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           <Box maxWidth="50%" sx={{ ml: 1 }}>
             <Burger.Switch
               checked={devMode}
-              helperText="services.devmode.helper"
-              label="services.devmode"
+              helperText="link.devmode.helper"
+              label="link.devmode"
               onChange={setDevMode}
             />
           </Box>

--- a/src/core/link/LinkComposer.tsx
+++ b/src/core/link/LinkComposer.tsx
@@ -21,9 +21,10 @@ const LinkComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [changeInProgress, setChangeInProgress] = React.useState(false);
   const [articleId, setArticleId] = React.useState<StencilClient.ArticleId[]>([]);
   //const articles: StencilClient.Article[] = Object.values(site.articles);
+  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   const handleCreate = () => {
-    const entity: StencilClient.CreateLink = { type, value, articles: articleId, labels };
+    const entity: StencilClient.CreateLink = { type, value, articles: articleId, labels, devMode };
     service.create().link(entity).then(success => {
       enqueueSnackbar(message, { variant: 'success' });
       console.log(success)
@@ -101,6 +102,14 @@ const LinkComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           })
           
           )} />
+          <Box maxWidth="50%" sx={{ ml: 1 }}>
+            <Burger.Switch
+              checked={devMode}
+              helperText="services.devmode.helper"
+              label="services.devmode"
+              onChange={setDevMode}
+            />
+          </Box>
       </>
     </Burger.Dialog>
   );

--- a/src/core/link/LinkEdit.tsx
+++ b/src/core/link/LinkEdit.tsx
@@ -32,9 +32,11 @@ const LinkEdit: React.FC<LinkEditProps> = ({ linkId, onClose }) => {
   //const locales = labels.map(l => l.locale);
   //const articles: StencilClient.Article[] = locales ? session.getArticlesForLocales(locales) : Object.values(site.articles);
 
+  const [devMode, setDevMode] = React.useState(link.body.devMode);
+
 
   const handleUpdate = () => {
-    const entity: StencilClient.LinkMutator = { linkId: link.id, type: contentType, articles: articleId, labels, value };
+    const entity: StencilClient.LinkMutator = { linkId: link.id, type: contentType, articles: articleId, labels, value, devMode };
     console.log("entity", entity)
     service.update().link(entity).then(success => {
       enqueueSnackbar(message, { variant: 'success' });
@@ -106,6 +108,14 @@ const LinkEdit: React.FC<LinkEditProps> = ({ linkId, onClose }) => {
         }
         ))}
       />
+      <Box maxWidth="50%" sx={{ ml: 1 }}>
+        <Burger.Switch
+          checked={devMode ? devMode : false}
+          helperText="services.devmode.helper"
+          label="services.devmode"
+          onChange={setDevMode}
+        />
+      </Box>
     </>
   </Burger.Dialog>
   );

--- a/src/core/link/LinkEdit.tsx
+++ b/src/core/link/LinkEdit.tsx
@@ -111,8 +111,8 @@ const LinkEdit: React.FC<LinkEditProps> = ({ linkId, onClose }) => {
       <Box maxWidth="50%" sx={{ ml: 1 }}>
         <Burger.Switch
           checked={devMode ? devMode : false}
-          helperText="services.devmode.helper"
-          label="services.devmode"
+          helperText="link.devmode.helper"
+          label="link.devmode"
           onChange={setDevMode}
         />
       </Box>

--- a/src/core/page/NewArticlePage.tsx
+++ b/src/core/page/NewArticlePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 import { useSnackbar } from 'notistack';
 
 import { FormattedMessage } from 'react-intl';
@@ -20,6 +20,7 @@ const NewArticlePage: React.FC<NewArticlePageProps> = ({ article, open, onClose,
   const { enqueueSnackbar } = useSnackbar();
   const { service, actions, site } = Composer.useComposer();
   const [template, setTemplate] = React.useState<StencilClient.TemplateId | ''>('');
+  const [devMode, setDevMode] = React.useState<boolean>(true);
 
   if (!open) {
     return null;
@@ -27,7 +28,7 @@ const NewArticlePage: React.FC<NewArticlePageProps> = ({ article, open, onClose,
 
   const handleCreate = () => {
     // const content = template ? site.templates[template].body.content : undefined;
-    const entity: StencilClient.CreatePage = { articleId: article.id, locale: open.id };
+    const entity: StencilClient.CreatePage = { articleId: article.id, locale: open.id, devMode };
     service.create().page(entity)
       .then(success => actions.handleLoadSite().then(() => success))
       .then(success => {
@@ -62,6 +63,14 @@ const NewArticlePage: React.FC<NewArticlePageProps> = ({ article, open, onClose,
             items={templates.map((template) => ({ id: template.id, value: template.body.name }))}
           />
           : null}
+        <Box maxWidth="50%" sx={{ ml: 1 }}>
+          <Burger.Switch
+            checked={devMode ? devMode : false}
+            helperText="services.devmode.helper"
+            label="services.devmode"
+            onChange={setDevMode}
+          />
+        </Box>
       </>
     </Burger.Dialog>
   );

--- a/src/core/page/NewPage.tsx
+++ b/src/core/page/NewPage.tsx
@@ -78,8 +78,8 @@ const NewPage: React.FC<{ onClose: () => void, articleId?: StencilClient.Article
         <Box maxWidth="50%" sx={{ ml: 1 }}>
           <Burger.Switch
             checked={devMode ? devMode : false}
-            helperText="services.devmode.helper"
-            label="services.devmode"
+            helperText="pages.devmode.helper"
+            label="pages.devmode"
             onChange={setDevMode}
           />
         </Box>

--- a/src/core/page/NewPage.tsx
+++ b/src/core/page/NewPage.tsx
@@ -15,7 +15,7 @@ const NewPage: React.FC<{ onClose: () => void, articleId?: StencilClient.Article
   const [locale, setLocale] = React.useState('');
   const [template, setTemplate] = React.useState<StencilClient.TemplateId | ''>('');
   const [articleId, setArticleId] = React.useState(props.articleId ? props.articleId : '');
-  const [devMode, setDevMode] = React.useState<boolean>(true);
+  const [devMode, setDevMode] = React.useState<boolean>(false);
   const { handleInTab } = Composer.useNav();
 
   const handleCreate = () => {

--- a/src/core/page/NewPage.tsx
+++ b/src/core/page/NewPage.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { Composer, StencilClient } from '../context';
 import Burger from '@the-wrench-io/react-burger';
+import { Box } from '@mui/material';
 
 
 
@@ -14,12 +15,13 @@ const NewPage: React.FC<{ onClose: () => void, articleId?: StencilClient.Article
   const [locale, setLocale] = React.useState('');
   const [template, setTemplate] = React.useState<StencilClient.TemplateId | ''>('');
   const [articleId, setArticleId] = React.useState(props.articleId ? props.articleId : '');
+  const [devMode, setDevMode] = React.useState<boolean>(true);
   const { handleInTab } = Composer.useNav();
 
   const handleCreate = () => {
 
     const content = template ? site.templates[template].body.content : undefined;
-    const entity: StencilClient.CreatePage = { articleId, locale, content };
+    const entity: StencilClient.CreatePage = { articleId, locale, content, devMode };
     service.create().page(entity).then(success => {
       enqueueSnackbar(message, { variant: 'success' });
       console.log(success)
@@ -73,7 +75,14 @@ const NewPage: React.FC<{ onClose: () => void, articleId?: StencilClient.Article
             items={templates.map((template) => ({ id: template.id, value: template.body.name }))}
           />
           : null}
-
+        <Box maxWidth="50%" sx={{ ml: 1 }}>
+          <Burger.Switch
+            checked={devMode ? devMode : false}
+            helperText="services.devmode.helper"
+            label="services.devmode"
+            onChange={setDevMode}
+          />
+        </Box>
       </>
     </Burger.Dialog>
   );

--- a/src/core/page/PageEdit.tsx
+++ b/src/core/page/PageEdit.tsx
@@ -4,6 +4,7 @@ import { useSnackbar } from 'notistack';
 
 import { Composer, StencilClient } from '../context';
 import Burger from '@the-wrench-io/react-burger';
+import { Box } from '@mui/material';
 
 
 
@@ -16,14 +17,14 @@ const PageEdit: React.FC<{ onClose: () => void, articleId: StencilClient.Article
   const [newLocale, setNewLocale] = React.useState('');
 
   const handleUpdate = () => {
-    const entity: StencilClient.PageMutator = { locale: newLocale, pageId, content: site.pages[pageId].body.content };
+    const entity: StencilClient.PageMutator = { locale: newLocale, pageId, content: site.pages[pageId].body.content, devMode: site.pages[pageId].body.devMode };
     service.update().pages([entity]).then(_success => {
       enqueueSnackbar(message, { variant: 'success' });
       props.onClose();
       actions.handleLoadSite();
     })
   }
-  const message = <FormattedMessage id="snack.page.editedMessage" />
+  const message = <FormattedMessage id="snack.page.savedMessage" />
   const articlePages: StencilClient.Page[] = Object.values(site.pages).filter(p => p.body.article === articleId);
   const usedLocales: StencilClient.LocaleId[] = articlePages.map(articlePage => articlePage.body.locale)
   const unusedLocales: StencilClient.SiteLocale[] = Object.values(site.locales).filter(siteLocale => !usedLocales.includes(siteLocale.id));
@@ -60,4 +61,61 @@ const PageEdit: React.FC<{ onClose: () => void, articleId: StencilClient.Article
   );
 }
 
-export { PageEdit }
+const PageEditDev: React.FC<{ onClose: () => void, articleId: StencilClient.ArticleId }> = (props) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const { service, actions, site } = Composer.useComposer();
+  const articleId = props.articleId;
+
+  const message = <FormattedMessage id="snack.page.savedMessage" />
+  const articlePages: StencilClient.Page[] = Object.values(site.pages).filter(p => p.body.article === articleId);
+
+  const [pageId, setPageId] = React.useState(articlePages[0].id);
+  const [devMode, setDevMode] = React.useState(site.pages[pageId].body.devMode || false);
+
+  React.useEffect(() => {
+    setDevMode(site.pages[pageId].body.devMode || false);
+  }, [pageId]);
+
+  const handleUpdate = () => {
+    const entity: StencilClient.PageMutator = { locale: site.pages[pageId].body.locale, pageId, content: site.pages[pageId].body.content, devMode };
+    console.log(entity)
+    service.update().pages([entity]).then(_success => {
+      enqueueSnackbar(message, { variant: 'success' });
+      props.onClose();
+      actions.handleLoadSite();
+    })
+  }
+
+  const valid = pageId && articleId;
+  return (
+    <Burger.Dialog open={true} onClose={props.onClose}
+      backgroundColor="uiElements.main" 
+      title="pages.change.devmode"
+      submit={{ title: "button.update", onClick: handleUpdate, disabled: !valid }}>
+
+      <>
+        <FormattedMessage id='pages.change.devmode.info' />
+        <Burger.Select
+          selected={pageId}
+          onChange={setPageId}
+          label='pages.edit.selectpage'
+          items={articlePages.map((articlePage) => ({
+            id: articlePage.id,
+            value: site.locales[articlePage.body.locale].body.value
+          }))}
+        />
+        {pageId.length > 0 && 
+        <Box maxWidth="50%" sx={{ ml: 1 }}>
+          <Burger.Switch
+            checked={devMode}
+            helperText="pages.devmode.helper"
+            label="pages.devmode"
+            onChange={setDevMode}
+          />
+        </Box>}
+      </>
+    </Burger.Dialog>
+  );
+}
+
+export { PageEdit, PageEditDev };

--- a/src/core/page/PageEdit.tsx
+++ b/src/core/page/PageEdit.tsx
@@ -4,8 +4,6 @@ import { useSnackbar } from 'notistack';
 
 import { Composer, StencilClient } from '../context';
 import Burger from '@the-wrench-io/react-burger';
-import { Box } from '@mui/material';
-
 
 
 const PageEdit: React.FC<{ onClose: () => void, articleId: StencilClient.ArticleId }> = (props) => {
@@ -61,61 +59,4 @@ const PageEdit: React.FC<{ onClose: () => void, articleId: StencilClient.Article
   );
 }
 
-const PageEditDev: React.FC<{ onClose: () => void, articleId: StencilClient.ArticleId }> = (props) => {
-  const { enqueueSnackbar } = useSnackbar();
-  const { service, actions, site } = Composer.useComposer();
-  const articleId = props.articleId;
-
-  const message = <FormattedMessage id="snack.page.savedMessage" />
-  const articlePages: StencilClient.Page[] = Object.values(site.pages).filter(p => p.body.article === articleId);
-
-  const [pageId, setPageId] = React.useState(articlePages[0].id);
-  const [devMode, setDevMode] = React.useState(site.pages[pageId].body.devMode || false);
-
-  React.useEffect(() => {
-    setDevMode(site.pages[pageId].body.devMode || false);
-  }, [pageId]);
-
-  const handleUpdate = () => {
-    const entity: StencilClient.PageMutator = { locale: site.pages[pageId].body.locale, pageId, content: site.pages[pageId].body.content, devMode };
-    console.log(entity)
-    service.update().pages([entity]).then(_success => {
-      enqueueSnackbar(message, { variant: 'success' });
-      props.onClose();
-      actions.handleLoadSite();
-    })
-  }
-
-  const valid = pageId && articleId;
-  return (
-    <Burger.Dialog open={true} onClose={props.onClose}
-      backgroundColor="uiElements.main" 
-      title="pages.change.devmode"
-      submit={{ title: "button.update", onClick: handleUpdate, disabled: !valid }}>
-
-      <>
-        <FormattedMessage id='pages.change.devmode.info' />
-        <Burger.Select
-          selected={pageId}
-          onChange={setPageId}
-          label='pages.edit.selectpage'
-          items={articlePages.map((articlePage) => ({
-            id: articlePage.id,
-            value: site.locales[articlePage.body.locale].body.value
-          }))}
-        />
-        {pageId.length > 0 && 
-        <Box maxWidth="50%" sx={{ ml: 1 }}>
-          <Burger.Switch
-            checked={devMode}
-            helperText="pages.devmode.helper"
-            label="pages.devmode"
-            onChange={setDevMode}
-          />
-        </Box>}
-      </>
-    </Burger.Dialog>
-  );
-}
-
-export { PageEdit, PageEditDev };
+export { PageEdit };

--- a/src/core/page/PageEditDevMode.tsx
+++ b/src/core/page/PageEditDevMode.tsx
@@ -20,7 +20,7 @@ const PageEditDevMode: React.FC<{ onClose: () => void, articleId: StencilClient.
   
     React.useEffect(() => {
       setDevMode(site.pages[pageId].body.devMode || false);
-    }, [pageId]);
+    }, [pageId, site.pages]);
   
     const handleUpdate = () => {
       const entity: StencilClient.PageMutator = { locale: site.pages[pageId].body.locale, pageId, content: site.pages[pageId].body.content, devMode };

--- a/src/core/page/PageEditDevMode.tsx
+++ b/src/core/page/PageEditDevMode.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useSnackbar } from 'notistack';
+
+import { Composer, StencilClient } from '../context';
+import Burger from '@the-wrench-io/react-burger';
+import { Box } from '@mui/material';
+
+
+const PageEditDevMode: React.FC<{ onClose: () => void, articleId: StencilClient.ArticleId }> = (props) => {
+    const { enqueueSnackbar } = useSnackbar();
+    const { service, actions, site } = Composer.useComposer();
+    const articleId = props.articleId;
+  
+    const message = <FormattedMessage id="snack.page.savedMessage" />
+    const articlePages: StencilClient.Page[] = Object.values(site.pages).filter(p => p.body.article === articleId);
+  
+    const [pageId, setPageId] = React.useState(articlePages[0].id);
+    const [devMode, setDevMode] = React.useState(site.pages[pageId].body.devMode || false);
+  
+    React.useEffect(() => {
+      setDevMode(site.pages[pageId].body.devMode || false);
+    }, [pageId]);
+  
+    const handleUpdate = () => {
+      const entity: StencilClient.PageMutator = { locale: site.pages[pageId].body.locale, pageId, content: site.pages[pageId].body.content, devMode };
+      console.log(entity)
+      service.update().pages([entity]).then(_success => {
+        enqueueSnackbar(message, { variant: 'success' });
+        props.onClose();
+        actions.handleLoadSite();
+      })
+    }
+  
+    const valid = pageId && articleId;
+    return (
+      <Burger.Dialog open={true} onClose={props.onClose}
+        backgroundColor="uiElements.main" 
+        title="pages.change.devmode"
+        submit={{ title: "button.update", onClick: handleUpdate, disabled: !valid }}>
+  
+        <>
+          <FormattedMessage id='pages.change.devmode.info' />
+          <Burger.Select
+            selected={pageId}
+            onChange={setPageId}
+            label='pages.edit.selectpage'
+            items={articlePages.map((articlePage) => ({
+              id: articlePage.id,
+              value: site.locales[articlePage.body.locale].body.value
+            }))}
+          />
+          {pageId.length > 0 && 
+          <Box maxWidth="50%" sx={{ ml: 1 }}>
+            <Burger.Switch
+              checked={devMode}
+              helperText="pages.devmode.helper"
+              label="pages.devmode"
+              onChange={setDevMode}
+            />
+          </Box>}
+        </>
+      </Burger.Dialog>
+    );
+}
+
+export { PageEditDevMode };

--- a/src/core/page/index.ts
+++ b/src/core/page/index.ts
@@ -2,3 +2,4 @@ export * from './NewPage';
 export * from './PageEdit';
 export * from './PageDelete';
 export * from './NewArticlePage';
+export * from './PageEditDevMode';

--- a/src/core/workflow/WorkflowComposer.tsx
+++ b/src/core/workflow/WorkflowComposer.tsx
@@ -14,7 +14,7 @@ const WorkflowComposer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { enqueueSnackbar } = useSnackbar();
   const { service, actions, site } = Composer.useComposer();
 
-  const [devMode, setDevMode] = React.useState<boolean>(true);
+  const [devMode, setDevMode] = React.useState<boolean>(false);
 
   let articleSelectOpen: boolean | undefined;
 

--- a/src/intl/en.ts
+++ b/src/intl/en.ts
@@ -167,7 +167,7 @@ const en = {
   'article.edit.title': 'Edit article',
   'article.edit.parent': 'Parent article',
   'article.edit.orderhelper': 'Three-digit number for ordering purposes',
-  'article.devmode.helper': 'If Development mode is active, this page will only appear in the development environment for testing. It will not be included in production releases.',
+  'article.devmode.helper': 'If Development mode is active, this article will only appear in the development environment for testing. It will not be included in production releases.',
   'article.devmode': 'Development mode',
 
   'articleservices': 'Article services: {name}',

--- a/src/intl/en.ts
+++ b/src/intl/en.ts
@@ -167,6 +167,8 @@ const en = {
   'article.edit.title': 'Edit article',
   'article.edit.parent': 'Parent article',
   'article.edit.orderhelper': 'Three-digit number for ordering purposes',
+  'article.devmode.helper': 'If Development mode is active, this page will only appear in the development environment for testing. It will not be included in production releases.',
+  'article.devmode': 'Development mode',
 
   'articleservices': 'Article services: {name}',
   'articlelinks': 'Article links: {name}',
@@ -213,6 +215,8 @@ const en = {
   'resource.edit.links': 'Edit links',
   'links.change': 'Change existing links',
   'link.create': 'Create new link',
+  'link.devmode.helper': 'If Development mode is active, this link will only appear in the development environment for testing. It will not be included in production releases.',
+  'link.devmode': 'Development mode',
 
   'locale.create': 'Create locale',
   'locale.disable.title': 'Disable this locale?',
@@ -238,6 +242,10 @@ const en = {
   'pages.add': 'Add a page',
   'pages.change': 'Change a page locale',
   'pages.change.info': 'Select a page from this Article and enter a new value for its locale.',
+  'pages.change.devmode': "Change a page's development mode",
+  'pages.change.devmode.info': 'Select a page from this Article and change its development mode.',
+  'pages.devmode.helper': 'If Development mode is active, this page will only appear in the development environment for testing. It will not be included in production releases.',
+  'pages.devmode': 'Development mode',
   'pages.delete': 'Delete a page',
   'pages.delete.message': 'Select a page to delete from this Article.',
   'pages.options': 'Page options',


### PR DESCRIPTION
### Development mode for articles, pages and links
- Added a Switch to toggle development mode to create dialogs for articles, pages and links
- Added a Switch to toggle development mode to edit dialogs for articles and links
- Added a new Dialog and ArticleOption to edit development mode for pages
- Handling icon changes for all assets - if an asset is in development mode a construction icon is displayed instead of the original